### PR TITLE
add judge for link

### DIFF
--- a/views/comments.ejs
+++ b/views/comments.ejs
@@ -17,7 +17,12 @@
         <li class="vcard">
             <div class="vhead">
                 <% if(comment_list[i].get('link')) { %>
-                    <a href="<%= comment_list[i].get('link') %>" target="_blank" rel="nofollow"> <%= comment_list[i].get('nick') %></a>
+                    <% var link = comment_list[i].get('link'); %>
+                    <% if(link.indexOf("//") != -1) { %>
+                        <a href="<%= link %>" target="_blank" rel="nofollow"> <%= comment_list[i].get('nick') %></a>
+                    <% } else { %>
+                        <a href="//<%= link %>" target="_blank" rel="nofollow"> <%= comment_list[i].get('nick') %></a>
+                    <% } %>
                 <% } else { %>
                     <span id="nick"><%= comment_list[i].get('nick') %></span>
                 <% } %>


### PR DESCRIPTION
增加对“评论中用户填写的网站”的判断。
![image](https://user-images.githubusercontent.com/18638530/57383802-0449be00-71e2-11e9-98fb-4955bd91dfd9.png)

网站可能不规范填写，如`www.baidu.com`。不带`http://`的话，会被`<a/>`标签识别为相对网址，在评论管理界面跳转时会产生问题。