### PR TITLE
set the ACL of spam comment record to nonreadable

### DIFF
--- a/utilities/check-spam.js
+++ b/utilities/check-spam.js
@@ -1,4 +1,5 @@
 'use strict';
+const AV = require('leanengine');
 const akismet = require('akismet-api');
 const akismetClient = akismet.client({
     key  : process.env.AKISMET_KEY,
@@ -33,6 +34,7 @@ exports.checkSpam = (comment, ip)=> {
                 if (spam) {
                     console.log('逮到一只垃圾评论，烧死它！用文火~');
                     comment.set('isSpam', true);
+                    comment.setACL(new AV.ACL({"*":{"read":false}}));
                     comment.save();
                     // comment.destroy();
                 } else {


### PR DESCRIPTION
HOOK检测到垃圾评论时，直接将垃圾评论的ACL设置为{"*":{"read":false}}

改变前：
1. 原版 Valine 前端会显示 isSpam 的评论（因为没做任何特殊处理）
2. Valine-Ex 不会显示评论（因为只 Query 'isSpam' == false 的评论）

改变后：
1. 所有前端（包括原版 Valine 和 Valine-Ex）均无法读取到该评论，由于没有相应的权限
2. 该评论可以在评论管理后台正常显示（因为后台用的是masterKey，有权限读取和修改）
3. Valine-Ex 也不需要专门筛选 'isSpam' == false 的评论了